### PR TITLE
refactor to use a frontend URL and rely on a reverse proxy for SSL ha…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,14 @@ You can override a number of configuration properties by creating a config_overr
 
 ```js
 {
-  "provider_domain": "https://example.com",
+  "frontend_url": "https://example.com/"
   "provider_port": "9008",
   "redis_host": "localhost",
-  "redis_port": 6379,
-  "use_ssl": true,
-  "ssl_key": "example.com.key",
-  "ssl_crt": "example.com.crt"
+  "redis_port": 6379
 }
 ```
 
-If you want to run under SSL you must specify the ssl_key and ssl_crt. They should be placed in the root folder of the application.
+If you want to run under SSL you should use a reverse proxy, like nginx.
 
 ## How To Run the code
 All packages needed are in the package.json.
@@ -68,49 +65,22 @@ A screencast of the rough LTI Advantage setup is shown in [Eric Preston's demo a
 
    On Mac it's easiest to `brew install redis`. The code assumes the default host and port (localhost:6379).
 
-2. Setup a domain with a self signed ssl certificate
+2. Start the server with `npm start`.
 
-   [Generate a self signed certificate](https://www.linux.com/tutorials/creating-self-signed-ssl-certificates-apache-linux/).  In this example:
-      - the FQDN is *example.com*
-      - the key is located in `/etc/httpd/ssl/example.com.key`
-      - the cert is located in `/etc/httpd/ssl/example.com.crt`
-
-   Add an entry in your `/etc/hosts` file to point localhost to *example.com*:
-
-      ```
-      127.0.0.1 localhost example.com
-      ```
-   Edit `server/config/config_override.json` to point to your key and secret for *example.com*
-
-      ```js
-      {
-        "provider_domain": "https://example.com",
-        "provider_port": "9008",
-        "redis_host": "localhost",
-        "redis_port": 6379,
-        "use_ssl": true,
-        "ssl_key": "/etc/httpd/ssl/example.com.key",
-        "ssl_crt": "/etc/httpd/ssl/example.com.crt"
-      }
-      ```
-
-3. Start the server with `npm start`.
-
-   Check that you can access https://example.com:3000/setup (you will receive self-signed certificate warnings)
+   Check that you can access https://example.com/setup
 
    You should see the following output:
 
    ```sh
-   Configuring for SSL use
-   Home page:  https://example.com:3000
-   LTI 1 Tool Provider:  https://example.com:3000/lti
-   LTI 1 Content Item: https://example.com:3000/CIMRequest
-   LTI 1.3 Login URL: https://example.com:3000/login
-   LTI 1.3 Redirect URL: https://example.com:3000/lti13,https://example.com:3000/deepLinkOptions
-   LTI 1.3 Launch URL: https://example.com:3000/lti13
-   LTI 1.3 Deep Linking URL: https://example.com:3000/deepLinkOptions
-   JWKS URL: https://example.com:3000/.well-known/jwks.json
-   Setup URL: https://example.com:3000/setup
+   Home page:  https://example.com
+   LTI 1 Tool Provider:  https://example.com/lti
+   LTI 1 Content Item: https://example.com/CIMRequest
+   LTI 1.3 Login URL: https://example.com/login
+   LTI 1.3 Redirect URL: https://example.com/lti13,https://example.com/deepLinkOptions
+   LTI 1.3 Launch URL: https://example.com/lti13
+   LTI 1.3 Deep Linking URL: https://example.com/deepLinkOptions
+   JWKS URL: https://example.com/.well-known/jwks.json
+   Setup URL: https://example.com/setup
    ```
 
 4. Register your application on the Blackboard Developer Portal
@@ -121,8 +91,8 @@ A screencast of the rough LTI Advantage setup is shown in [Eric Preston's demo a
       - *Application Name*: LTI 1.3 Example App
       - *Description*: LTI 1.3 example App
       - *Domain(s)*: example.com
-      - *Login Initiation URL*: https://example.com:3000/login
-      - *Tool Redirect URL(s)*: https://example.com:3000/lti13,https://example.com:3000/deepLinkOptions
+      - *Login Initiation URL*: https://example.com/login
+      - *Tool Redirect URL(s)*: https://example.com/lti13,https://example.com/deepLinkOptions
 
       Click *Register application and generate API key*
 
@@ -136,7 +106,7 @@ A screencast of the rough LTI Advantage setup is shown in [Eric Preston's demo a
 
 5. Configure the server
 
-   Navigate to https://example.com:3000/setup and enter the following fields:
+   Navigate to https://example.com/setup and enter the following fields:
    - *Developer portal URL*: https://developer.blackboard.com
    - *Application Id*: The *Application ID* from the developer portal
    - *OAuth2 Token End Point*: The *Auth token endpoint* from the developer portal
@@ -160,7 +130,7 @@ A screencast of the rough LTI Advantage setup is shown in [Eric Preston's demo a
      -  *Label*: LTI 1.3 Example App
      -  *Handle*: LTI 1.3 Example App
      - *Type*: Course tool
-     - *Tool Provider URL*: https://example.com:3000/lti13
+     - *Tool Provider URL*: https://example.com/lti13
 
    Click *Submit*
 
@@ -178,7 +148,7 @@ If enabled on the LMS this will be available in the tool.
 If enabled on the LMS this will be available in the tool.
 
 ## Deep Linking 2.0
-The Deep Linking Request should launch to http://localhost:3000/deepLinkOptions to be able to select content items and counts to return. Possible content items are:
+The Deep Linking Request should launch to http://localhost/deepLinkOptions to be able to select content items and counts to return. Possible content items are:
 - LTI Link
 - Content Link
 

--- a/server/config/config.json
+++ b/server/config/config.json
@@ -1,9 +1,6 @@
 {
-  "provider_domain": "http://localhost",
+  "frontend_url": "http://localhost/",
   "provider_port": "3000",
   "redis_host": "localhost",
-  "redis_port": 6379,
-  "use_ssl": false,
-  "ssl_key": "",
-  "ssl_crt": ""
+  "redis_port": 6379
 }

--- a/server/config/marathon_config_override.json
+++ b/server/config/marathon_config_override.json
@@ -1,7 +1,0 @@
-{
-  "provider_domain": "https://lti-tool.dev.bbpd.io",
-  "provider_port": "NA",
-  "redis_host": "localhost",
-  "redis_port": 6379,
-  "use_ssl": false
-}

--- a/server/src/app/deep-linking.js
+++ b/server/src/app/deep-linking.js
@@ -139,10 +139,7 @@ let deepLinkingLTILink = function() {
     type: "ltiResourceLink",
     title: "A title for LTI Link",
     text: "A description",
-    url:
-      config.provider_domain +
-      (config.provider_port !== "NA" ? ":" + config.provider_port : "") +
-      "/lti13",
+    url:  `${config.frontend_url}lti13`,
     available: {
       startDateTime: start,
       endDateTime: end
@@ -191,10 +188,7 @@ let deepLinkingEmbedLTILink = function() {
     type: "ltiResourceLink",
     title: "An Embedded LTI Link",
     text: "Bobcat art",
-    url:
-      config.provider_domain +
-      (config.provider_port !== "NA" ? ":" + config.provider_port : "") +
-      "/lti13bobcat",
+    url: `${config.frontend_url}lti13bobcat`,
     iframe: {
       width: 600,
       height: 600

--- a/server/src/app/lti-content-item.js
+++ b/server/src/app/lti-content-item.js
@@ -7,9 +7,7 @@ module.exports = {
       "@graph": [
         {
           "@type": "LtiLinkItem",
-          url: config.provider_domain +
-            (config.provider_port !== "NA" ? ":" + config.provider_port : "") +
-            "/lti",
+          url: `${config.frontend_url}lti`,
           mediaType: "application/vnd.ims.lti.v1.ltilink",
           icon: {
             "@id":
@@ -34,9 +32,7 @@ module.exports = {
         },
         {
           "@type": "LtiLinkItem",
-          url: config.provider_domain +
-            (config.provider_port !== "NA" ? ":" + config.provider_port : "") +
-            "/lti",
+          url: `${config.frontend_url}lti`,
           mediaType: "application/vnd.ims.lti.v1.ltilink",
           icon: {
             "@id":
@@ -119,7 +115,7 @@ module.exports = {
         {
           mediaType: "application/vnd.ims.lti.v1.ltilink",
           "@type": "LtiLinkItem",
-          url: config.provider_domain + ":" + config.provider_port + "/lti",
+          url: `${config.provider_domain}lti`,
           title: "Sample LTI launch",
           text:
             "This is an example of an LTI launch link set via the Content-Item launch message.  Please launch it to pass the related certification test.",

--- a/server/src/app/routes.js
+++ b/server/src/app/routes.js
@@ -42,9 +42,7 @@ const PUBLIC_KEY_SET = "{\n" +
 module.exports = function(app) {
   app.use(cookieParser());
 
-  let provider =
-    config.provider_domain +
-    (config.provider_port !== "NA" ? ":" + config.provider_port : "");
+  const frontendUrl = config.frontend_url;
 
   let contentItemData = new ContentItem();
   let ciLoaded = false;
@@ -67,7 +65,7 @@ module.exports = function(app) {
   }
 
   //=======================================================
-  // LTI 1 provider and caliper stuff
+  // LTI 1.1 provider and caliper stuff
   app.post('/caliper/send', (req, res) => {
     lti.caliper_send(req, res);
   });
@@ -105,7 +103,7 @@ module.exports = function(app) {
         redisUtil.redisSave(contentitem_key, contentItemData);
         ciLoaded = true;
 
-        let redirectUrl = provider + "/content_item";
+        const redirectUrl = `${frontendUrl}content_item`;
         console.log("Redirecting to : " + redirectUrl);
         res.redirect(redirectUrl);
       });
@@ -130,7 +128,7 @@ module.exports = function(app) {
   let passthru = false;
 
   app.post("/CIMRequest", (req, res) => {
-    console.log("--------------------\nCIMRequest Provider URL in routes: " + provider);
+    console.log("--------------------\nCIMRequest frontend URL in routes: " + frontendUrl);
 
     if (req.body.custom_option === undefined) {
       // no custom_option set so go to CIM request menu and save req and res to pass through
@@ -156,7 +154,7 @@ module.exports = function(app) {
           redisUtil.redisSave(contentitem_key, contentItemData);
           ciLoaded = true;
 
-          let redirectUrl = provider + "/content_item";
+          const redirectUrl = `${frontendUrl}content_item`;
           console.log("Redirecting to : " + redirectUrl);
           res.redirect(redirectUrl);
         });

--- a/server/src/config/config.js
+++ b/server/src/config/config.js
@@ -31,7 +31,7 @@ if (process.env.REDIS_URL) {
   configResult["redis_url"] = process.env.REDIS_URL;
 }
 if (process.env.LTI_TEST_PROVIDER_DOMAIN) {
-  configResult["provider_domain"] = process.env.LTI_TEST_PROVIDER_DOMAIN;
+  configResult["frontend_url"] = process.env.LTI_TEST_PROVIDER_DOMAIN;
 }
 if (process.env.LTI_TEST_PROVIDER_PORT) {
   configResult["provider_port"] = process.env.LTI_TEST_PROVIDER_PORT;

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,7 +1,6 @@
 import bodyParser from "body-parser";
 import express from "express";
 import fs from "fs";
-import https from "https";
 import request from "request";
 import routes from "./app/routes.js";
 import config from "./config/config.js";
@@ -12,14 +11,11 @@ let redisUtil = require("./app/redisutil");
 
 const options = config.use_ssl
   ? {
-      key: fs.readFileSync(config.ssl_key),
-      cert: fs.readFileSync(config.ssl_crt)
-    }
-  : { key: null, cert: null };
+    key: fs.readFileSync(config.ssl_key),
+    cert: fs.readFileSync(config.ssl_crt)
+  }
+  : {key: null, cert: null};
 
-let provider =
-  config.provider_domain +
-  (config.provider_port !== "NA" ? ":" + config.provider_port : "");
 let listenPort =
   process.env.PORT ||
   (config.provider_port !== "NA" ? config.provider_port : 5000);
@@ -51,13 +47,13 @@ app.use(
   })
 );
 
-httpProxy.use(function(err, req, res) {
+httpProxy.use(function (err, req, res) {
   console.error(err.stack);
   res.status(500).send("Something broke!");
 });
 
 //httpProxy.use(bodyParser.json());       // to support JSON-encoded bodies
-httpProxy.use(bodyParser.json({ type: "*/*" }));
+httpProxy.use(bodyParser.json({type: "*/*"}));
 httpProxy.use((req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
   res.header(
@@ -68,7 +64,7 @@ httpProxy.use((req, res, next) => {
   next();
 });
 
-httpProxy.all("/*", function(req, res) {
+httpProxy.all("/*", function (req, res) {
   //modify the url in any way you want
   let learnUrl = "https://isthisthingon.hopto.org" + req.url;
 
@@ -132,32 +128,16 @@ routes(app);
 
 // listen (start app with node server.js) ======================================
 
-//httpProxy.listen(8543);
+app.listen(listenPort);
+const frontendUrl = config.frontend_url;
 
-if (config.use_ssl) {
-  https.createServer(options, app).listen(listenPort, function() {
-    console.log("Configuring for SSL use");
-    console.log("Home page:  " + provider);
-    console.log("LTI 1 Tool Provider:  " + provider + "/lti");
-    console.log("LTI 1 Content Item: " + provider + "/CIMRequest");
-    console.log("LTI 1.3 Login URL: " + provider + "/login");
-    console.log("LTI 1.3 Redirect URL: " + provider + "/lti13," + provider + "/deepLinkOptions");
-    console.log("LTI 1.3 Launch URL: " + provider + "/lti13");
-    console.log("LTI 1.3 Deep Linking URL: " + provider + "/deepLinkOptions");
-    console.log("JWKS URL: " + provider + "/.well-known/jwks.json");
-    console.log("Setup URL: " + provider + "/setup");
-    console.log("Listening on " + listenPort);
-  });
-} else {
-  app.listen(listenPort);
-  console.log("Home page:  " + provider);
-  console.log("LTI 1 Tool Provider:  " + provider + "/lti");
-  console.log("LTI 1 Content Item: " + provider + "/CIMRequest");
-  console.log("LTI 1.3 Login URL: " + provider + "/login");
-  console.log("LTI 1.3 Redirect URL: " + provider + "/lti13," + provider + "/deepLinkOptions");
-  console.log("LTI 1.3 Launch URL: " + provider + "/lti13");
-  console.log("LTI 1.3 Deep Linking URL: " + provider + "/deepLinkOptions");
-  console.log("JWKS URL: " + provider + "/.well-known/jwks.json");
-  console.log("Setup URL: " + provider + "/setup");
-  console.log("Listening on " + listenPort);
-}
+console.log("Home page:  " + frontendUrl);
+console.log("LTI 1 Tool Provider:  " + frontendUrl + "lti");
+console.log("LTI 1 Content Item: " + frontendUrl + "CIMRequest");
+console.log("LTI 1.3 Login URL: " + frontendUrl + "login");
+console.log("LTI 1.3 Redirect URL: " + frontendUrl + "lti13," + frontendUrl + "deepLinkOptions");
+console.log("LTI 1.3 Launch URL: " + frontendUrl + "lti13");
+console.log("LTI 1.3 Deep Linking URL: " + frontendUrl + "deepLinkOptions");
+console.log("JWKS URL: " + frontendUrl + ".well-known/jwks.json");
+console.log("Setup URL: " + frontendUrl + "setup");
+console.log("Listening on " + listenPort);


### PR DESCRIPTION
Removed local SSL support to make it clearer and easier how to get the server to handle incoming requests and build URLs back to itself. Use a reverse proxy (like nginx) for SSL support