### PR TITLE
Fix startup hang

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+.git
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN mkdir -p /usr/app
 WORKDIR /usr/app
 
 # Install app dependencies
-COPY package.json /usr/app/
-RUN npm install
+COPY package.json package-lock.json /usr/app/
+RUN npm ci --ignore-scripts
 
 # Bundle app source
 COPY . /usr/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN npm ci --ignore-scripts
 
 # Bundle app source
 COPY . /usr/app
+RUN npm run build-server && npm run build-public
 
 VOLUME /data
 

--- a/launch.sh
+++ b/launch.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo $HOST_ENTRY >>/etc/hosts
-npm start
+node server/lib/server.js


### PR DESCRIPTION
We recently saw an issue where the Docker container was hanging during startup. Attempting to build the Docker image locally shows the same problem; `npm install` is hanging.

I see two problems with the current code:
1. The `package-lock.json` is not being included in the Docker image, so version-pinned dependencies are being ignored
2. Compile actions are being performed during container startup, when they should only need to be run once during the image build.