### PR TITLE
Added custom claim in order to get MSFT Cloud Document integration

### DIFF
--- a/server/src/app/deep-linking.js
+++ b/server/src/app/deep-linking.js
@@ -168,6 +168,7 @@ let deepLinkingLTILink = function () {
       firstAvailable: '$ResourceLink.available.startDateTime',
       lastAvailable: '$ResourceLink.available.endDateTime',
       dueDate: '$ResourceLink.submission.endDateTime',
+      groupId: '$CourseGroup.id',
       userName: '$User.username',
       userEmail: '$Person.email.primary',
       userSysRoles: '@X@user.role@X@',
@@ -197,6 +198,7 @@ let deepLinkingNewWindowLTILink = function () {
       key1: 'new window & link value',
       userName: '$User.username',
       userEmail: '$Person.email.primary',
+      groupId: '$CourseGroup.id',
       userSysRoles: '@X@user.role@X@',
       source: 'new window link'
     },
@@ -225,6 +227,7 @@ let deepLinkingEmbedLTILink = function () {
     custom: {
       deeplinkkey1: 'from deep linking & item',
       userName: '$User.username',
+      groupId: '$CourseGroup.id',
       userEmail: '$Person.email.primary',
       userSysRoles: '@X@user.role@X@',
       assignment_pk: '@X@content.pk_string@X@',


### PR DESCRIPTION
### This PR intents to add a custom variable to test the CourseGroup.id which was requested by the MSFT team for the integrations of One Drive Collaborative Documents.

This excerpt from **LTI Spec Group** is from the _IMS Global Team_ : 
https://github.com/IMSGlobal/lti-spec-groups/blob/master/docs/groups-spec.md#group-substitution-variables

#### Group Substitution Variables
Course groups and course memberships may have a many to many relationship. This means that a member can belong to multiple groups within a course. When performing an LTI launch, a tool may request a LaunchGroup variable to accept any specific course group that might be associated to the launch.

#### `**CourseGroup.id**`
This variable will be substituted with the ID of any one **context group** asociated with the launch, or an empty string if there is no group associated with the launch. This is intended for tools that offer group activities and need to know which group the launch is intended for. The existence of this variable and any value it holds will not mean the launch user is part of the provided context group. For example, an instructor may launch a group activity of a course group where they not a member. Any id value provided by the platform must be of a group in the context course and must never be an id of a group outside the course context.
