### PR TITLE
Added new substitution variable in custom claim for user UPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,17 @@ Custom JSON can also be entered and used to create deep linked items.
 Docker specific files are included (Dockerfile, docker-compose.yml, launch.sh).
 
 Build the LTI tool container with `docker build -t lti-tool .`. Then start containers using `docker-compose up`.
+
+# Substituion variables:
+
+- **$CourseGroup.id**
+
+  To be used for the integration of Cloud Document contents. Resolve the UUID of the assigned group of the content.
+
+  - `minimum-learn-version` : _To be used internally for now. Minium version to be defined._
+  
+- **$User.externalIdentifiers.UPN** _for Microsoft_
+
+  To be used for the integration of Cloud Document contents. Resolve the UPN (User Personal Name) of a user for this Microsoft Integration. For Ultra, the UPN will be the registered institutional email  of the user.
+
+  - `minimum-learn-version` : _To be used internally for now. Minimun version to be defined._

--- a/server/src/app/deep-linking.js
+++ b/server/src/app/deep-linking.js
@@ -172,6 +172,7 @@ let deepLinkingLTILink = function () {
       userName: '$User.username',
       userEmail: '$Person.email.primary',
       userSysRoles: '@X@user.role@X@',
+      externalIdentifierUPN: '$User.externalIdentifiers.UPN',
       source: 'link'
     }
   };
@@ -200,6 +201,7 @@ let deepLinkingNewWindowLTILink = function () {
       userEmail: '$Person.email.primary',
       groupId: '$CourseGroup.id',
       userSysRoles: '@X@user.role@X@',
+      externalIdentifierUPN: '$User.externalIdentifiers.UPN',
       source: 'new window link'
     },
     window: {
@@ -230,6 +232,7 @@ let deepLinkingEmbedLTILink = function () {
       groupId: '$CourseGroup.id',
       userEmail: '$Person.email.primary',
       userSysRoles: '@X@user.role@X@',
+      externalIdentifierUPN: '$User.externalIdentifiers.UPN',
       assignment_pk: '@X@content.pk_string@X@',
       course_pk: '@X@course.pk_string@X@'
     }


### PR DESCRIPTION
A new custom claim was added in the deep-linking payload in order to send the Group Members ID (UPN) to the Microsoft Integration.