### PR TITLE
also test https://www.imsglobal.org/spec/lti-nrps/v2p0\#resource-link…

### DIFF
--- a/server/src/app/names-roles.js
+++ b/server/src/app/names-roles.js
@@ -4,11 +4,14 @@ import { getCachedLTIToken } from './lti-token-service';
 export const namesRoles = (req, res, nrPayload) => {
   if (nrPayload.url === '') {
     nrPayload.orig_body = JSON.parse(req.body.body);
+    let rlid = nrPayload.orig_body[
+      'https://purl.imsglobal.org/spec/lti/claim/resource_link'
+    ].id;
     let namesRoles =
       nrPayload.orig_body[
         'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice'
       ];
-    nrPayload.url = namesRoles.context_memberships_url + '?groups=true';
+    nrPayload.url = namesRoles.context_memberships_url + '?groups=true&rlid=' + rlid;
     nrPayload.version = namesRoles.service_version;
     nrPayload.return_url =
       nrPayload.orig_body[


### PR DESCRIPTION
…-membership-service Added this so we can test the https://www.imsglobal.org/spec/lti-nrps/v2p0#resource-link-membership-service portion of the spec when exercising the NRPS of Learn. This came up as a vendor found that Learn's not sending a list [] of objects for the "message":  object. We leave out the [. With this addition, you can see that in the response from Learn to the NRPS GET. 

"message" : [ <-- this is missing. Will be filing a Learn bug to address.
      {
        "https://purl.imsglobal.org/spec/lti/claim/message_type" : "LtiResourceLinkRequest",
        "https://purl.imsglobal.org/spec/lti-bo/claim/basicoutcome" : {