### PR TITLE
Added button to test Microphone and display Cap

### DIFF
--- a/public/src/components/pages/ltiAdvView.js
+++ b/public/src/components/pages/ltiAdvView.js
@@ -18,7 +18,7 @@ export default class LtiAdvView extends React.Component {
   componentDidMount() {
     fetch(`jwtPayloadData?nonce=${params.getNonce()}`)
       .then(result => result.json())
-      .then(jwtPayload => {
+      .then(jwtPayload => {        
         this.setState({
           header: jwtPayload.header,
           body: jwtPayload.body,
@@ -96,6 +96,34 @@ export default class LtiAdvView extends React.Component {
       </Typography>
     );
 
+    const checkMicroPhone = () => {
+      navigator.mediaDevices.getUserMedia({ audio: true }). then (
+        function(stream) {
+          alert('Microphone access granted!', stream);
+        }
+      );
+
+      navigator.mediaDevices.getUserMedia({ audio: true }). catch (
+        function(error) {
+          alert('Microphone access denied!', error);
+        }
+      );
+    };
+
+    const checkDisplayCap = () => {
+      navigator.mediaDevices.getDisplayMedia({ video: true }). then (
+        function(stream) {
+          alert('Display capture access granted!', stream);
+        }
+      );
+
+      navigator.mediaDevices.getDisplayMedia({ video: true }). catch (
+        function(error) {
+          alert('Display capture access denied:', error);
+        }
+      );
+    };
+
     return (
       <div>
         <Typography variant='h4' gutterBottom>
@@ -114,6 +142,12 @@ export default class LtiAdvView extends React.Component {
             direction='column'
             spacing={2}
           >
+            <Grid item xs>
+              <Button variant='contained' color='secondary' onClick={() => checkMicroPhone()}>Test MicroPhone</Button>
+            </Grid>
+            <Grid item xs>
+              <Button variant='contained' color='secondary' onClick={() => checkDisplayCap()}>Test Display Capture</Button>
+            </Grid>
             <Grid item xs>
               <form action={this.state.returnUrl} method='post'>
                 <Button variant='contained' type='submit' color='secondary'>Return to Learn</Button>

--- a/public/src/components/pages/ltiAdvView.js
+++ b/public/src/components/pages/ltiAdvView.js
@@ -112,7 +112,11 @@ export default class LtiAdvView extends React.Component {
         .catch(error => alert('Display capture access denied', error));
     };
     const closeTracks = (stream) => {
-      console.log(stream);
+      stream.getTracks().forEach(track => {
+        if (track.readyState == 'live') {
+          track.stop();
+        }
+      });
     };
     return (
       <div>

--- a/public/src/components/pages/ltiAdvView.js
+++ b/public/src/components/pages/ltiAdvView.js
@@ -95,7 +95,7 @@ export default class LtiAdvView extends React.Component {
         <b>Group Sets not available</b>
       </Typography>
     );
-    const checkMicroPhone = () => {
+    const checkMicrophone = () => {
       navigator.mediaDevices.getUserMedia({ audio: true })
         .then(stream => {
           alert('Microphone access granted!');
@@ -106,10 +106,10 @@ export default class LtiAdvView extends React.Component {
     const checkDisplayCap = () => {
       navigator.mediaDevices.getDisplayMedia({ video: true })
         .then(stream => {
-          alert('Display capture access granted');
+          alert('Display capture access granted!');
           closeTracks(stream);
         })
-        .catch(error => alert('Display capture access denied', error));
+        .catch(error => alert('Display capture access denied!', error));
     };
     const closeTracks = (stream) => {
       stream.getTracks().forEach(track => {
@@ -137,7 +137,7 @@ export default class LtiAdvView extends React.Component {
             spacing={2}
           >
             <Grid item xs>
-              <Button variant='contained' color='secondary' onClick={() => checkMicroPhone()}>Test MicroPhone</Button>
+              <Button variant='contained' color='secondary' onClick={() => checkMicrophone()}>Test MicroPhone</Button>
             </Grid>
             <Grid item xs>
               <Button variant='contained' color='secondary' onClick={() => checkDisplayCap()}>Test Display Capture</Button>

--- a/public/src/components/pages/ltiAdvView.js
+++ b/public/src/components/pages/ltiAdvView.js
@@ -18,7 +18,7 @@ export default class LtiAdvView extends React.Component {
   componentDidMount() {
     fetch(`jwtPayloadData?nonce=${params.getNonce()}`)
       .then(result => result.json())
-      .then(jwtPayload => {        
+      .then(jwtPayload => {
         this.setState({
           header: jwtPayload.header,
           body: jwtPayload.body,

--- a/public/src/components/pages/ltiAdvView.js
+++ b/public/src/components/pages/ltiAdvView.js
@@ -95,35 +95,25 @@ export default class LtiAdvView extends React.Component {
         <b>Group Sets not available</b>
       </Typography>
     );
-
     const checkMicroPhone = () => {
-      navigator.mediaDevices.getUserMedia({ audio: true }). then (
-        function(stream) {
-          alert('Microphone access granted!', stream);
-        }
-      );
-
-      navigator.mediaDevices.getUserMedia({ audio: true }). catch (
-        function(error) {
-          alert('Microphone access denied!', error);
-        }
-      );
+      navigator.mediaDevices.getUserMedia({ audio: true })
+        .then(stream => {
+          alert('Microphone access granted!');
+          closeTracks(stream);
+        })
+        .catch(error => alert('Microphone access denied!', error));
     };
-
     const checkDisplayCap = () => {
-      navigator.mediaDevices.getDisplayMedia({ video: true }). then (
-        function(stream) {
-          alert('Display capture access granted!', stream);
-        }
-      );
-
-      navigator.mediaDevices.getDisplayMedia({ video: true }). catch (
-        function(error) {
-          alert('Display capture access denied:', error);
-        }
-      );
+      navigator.mediaDevices.getDisplayMedia({ video: true })
+        .then(stream => {
+          alert('Display capture access granted');
+          closeTracks(stream);
+        })
+        .catch(error => alert('Display capture access denied', error));
     };
-
+    const closeTracks = (stream) => {
+      console.log(stream);
+    };
     return (
       <div>
         <Typography variant='h4' gutterBottom>


### PR DESCRIPTION
Additional two buttons added to test Micro Phone and Display capture. 

What was the issue:

[LRN-180381](https://jira.bbpd.io/browse/LRN-180381) & [LRN-194962](https://jira.bbpd.io/browse/LRN-194962)
To address the defect, we must permit LTI iframe HTML tags with the “allow” attribute values “display-capture *” and “microphone *.”
The “display-capture *” attribute enables embedded content to capture the user’s device display, commonly used in video conferencing or screen sharing applications.
In contrast, the “microphone *” attribute enables embedded content to access the user’s microphone, frequently used in voice recognition, video or audio conferencing, and voice recording applications.
Although we have implemented changes in Learn and Ultra applications, we lack the ability to test the modifications in the local environment using the LTI admin tool.

What was the risk:

We do not currently have any functionality to test the changes using the LTI admin tool. As a result, we are unable to test the changes in the local environment and cannot proceed with QA branch testing.

How did we overcome that:

We have added further functionality to the LTI admin tool to test microphone and display capture access for a specific LTI iframe HTML tag. When the iframe is granted access to the microphone and display capture, an alert box indicating “access granted” will be displayed. Conversely, if access is denied, an error message will appear in the alert box.