### PR TITLE
AB#2242239: Asset processor substitution variables

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="icon" href="https://cdn.glitch.com/749a41a4-f5f2-4610-b5ed-1b66fc83a42b%2Ffavicon.ico?1554292700459"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" />
     <title>LTI Testing Tool</title>
 </head>

--- a/server/src/app/deep-linking.js
+++ b/server/src/app/deep-linking.js
@@ -293,16 +293,16 @@ let deepLinkingImage = function () {
 
 let deepLinkingProcessor = function () {
   return {
-    "type": "ltiAssetProcessor",
-    "title": null,
-    "text": null,
-    "url": null,
-    "lineItem": null,
-    "presentation": null,
-    "submission": null,
-    "available": null,
-    "custom": {
-      "reports_released": "$ReportsReleased"
+    type: 'ltiAssetProcessor',
+    title: null,
+    text: null,
+    url: null,
+    lineItem: null,
+    presentation: null,
+    submission: null,
+    available: null,
+    custom: {
+      reports_released: '$ReportsReleased',
     }
   };
 };

--- a/server/src/app/deep-linking.js
+++ b/server/src/app/deep-linking.js
@@ -303,8 +303,7 @@ let deepLinkingProcessor = function () {
     available: null,
     custom: {
       reports_released: '$ReportsReleased',
+      due_date: '$ResourceLink.submission.endDateTime',
     }
   };
 };
-
-

--- a/server/src/app/processor.js
+++ b/server/src/app/processor.js
@@ -1,148 +1,148 @@
 import { getProcessorToken } from './lti-token-service';
-import request from "request";
+import request from 'request';
 
 const SUBMISSION_TEXT_TITLE = 'Submission_Text.html';
 
 export const handleSubmissionNotice = async (req, res, jwtPayload) => {
-    // We need to store the assets
-    const assets = jwtPayload.body["https://purl.imsglobal.org/spec/lti-ap/claim/assetservice"]["assets"];
-    const statusUrl = jwtPayload.body["https://purl.imsglobal.org/spec/lti-ap/claim/assetreport"]["report_url"];
-    const resourceLinkId = jwtPayload.body["https://purl.imsglobal.org/spec/lti/claim/resource_link"]["id"];
+  // We need to store the assets
+  const assets = jwtPayload.body['https://purl.imsglobal.org/spec/lti-ap/claim/assetservice']['assets'];
+  const statusUrl = jwtPayload.body['https://purl.imsglobal.org/spec/lti-ap/claim/assetreport']['report_url'];
+  const resourceLinkId = jwtPayload.body['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id'];
 
-    const nonSubmissionTextTitle = assets.find(asset => asset.title !== SUBMISSION_TEXT_TITLE)?.title;
+  const nonSubmissionTextTitle = assets.find(asset => asset.title !== SUBMISSION_TEXT_TITLE)?.title;
 
-    for (const asset in assets) {
-        const currentAssetTitle = assets[asset].title;
+  for (const asset in assets) {
+    const currentAssetTitle = assets[asset].title;
 
-        // Since we can't manually specify a title for submission text, get the score and status
-        // from the title of the first file attachment
-        let titleToParse;
-        if (nonSubmissionTextTitle && (currentAssetTitle === SUBMISSION_TEXT_TITLE)) {
-            titleToParse = nonSubmissionTextTitle;
-        } else {
-            titleToParse = currentAssetTitle;
-        }
-
-        // Delay downloading/updating status for 1 second after notification
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        await downloadAsset(jwtPayload.body.aud, assets[asset].url);
-        await updateAssetStatus(jwtPayload.body.aud, statusUrl, resourceLinkId, assets[asset].asset_id, "Processing");
-        if (titleToParse.startsWith('fail')) {
-            await updateAssetStatus(jwtPayload.body.aud, statusUrl, resourceLinkId, assets[asset].asset_id, "Failed");
-        } else if (titleToParse.startsWith('notprocessed')) {
-            await updateAssetStatus(jwtPayload.body.aud, statusUrl, resourceLinkId, assets[asset].asset_id, "NotProcessed");
-        } else {
-            const score = parseScore(titleToParse);
-            const maxScore = parseMaxScore(titleToParse);
-            await updateAssetStatus(jwtPayload.body.aud, statusUrl, resourceLinkId, assets[asset].asset_id, "Processed", score, maxScore);
-        }
+    // Since we can't manually specify a title for submission text, get the score and status
+    // from the title of the first file attachment
+    let titleToParse;
+    if (nonSubmissionTextTitle && (currentAssetTitle === SUBMISSION_TEXT_TITLE)) {
+      titleToParse = nonSubmissionTextTitle;
+    } else {
+      titleToParse = currentAssetTitle;
     }
-    res.sendStatus(200);
+
+    // Delay downloading/updating status for 1 second after notification
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    await downloadAsset(jwtPayload.body.aud, assets[asset].url);
+    await updateAssetStatus(jwtPayload.body.aud, statusUrl, resourceLinkId, assets[asset].asset_id, 'Processing');
+    if (titleToParse.startsWith('fail')) {
+      await updateAssetStatus(jwtPayload.body.aud, statusUrl, resourceLinkId, assets[asset].asset_id, 'Failed');
+    } else if (titleToParse.startsWith('notprocessed')) {
+      await updateAssetStatus(jwtPayload.body.aud, statusUrl, resourceLinkId, assets[asset].asset_id, 'NotProcessed');
+    } else {
+      const score = parseScore(titleToParse);
+      const maxScore = parseMaxScore(titleToParse);
+      await updateAssetStatus(jwtPayload.body.aud, statusUrl, resourceLinkId, assets[asset].asset_id, 'Processed', score, maxScore);
+    }
+  }
+  res.sendStatus(200);
 };
 
 const parseScore = (title) => {
-    // This regex matches numbers with optional decimal part
-    const score = title.match(/(\d+(\.\d+)?)/);
-    return score ? Number(score[0]) : 75;
-}
+  // This regex matches numbers with optional decimal part
+  const score = title.match(/(\d+(\.\d+)?)/);
+  return score ? Number(score[0]) : 75;
+};
 
 const parseMaxScore = (title) => {
-    // This regex matches numbers with optional decimal part at the end of a string
-    const score = title.match(/(\d+(\.\d+)?)(?=\.\w+$)/);
-    return score ? Number(score[0]) : 100;
-}
+  // This regex matches numbers with optional decimal part at the end of a string
+  const score = title.match(/(\d+(\.\d+)?)(?=\.\w+$)/);
+  return score ? Number(score[0]) : 100;
+};
 
 const downloadAsset = (aud, assetUrl) => {
-    return new Promise(async (resolve, reject) => {
-        const scope = "https://purl.imsglobal.org/spec/lti-ap/scope/asset.readonly";
-        try {
-            const token = await getProcessorToken(aud, scope);
-            let options = {
-                method: 'GET',
-                uri: assetUrl,
-                headers: {
-                    Authorization: 'Bearer ' + token
-                },
-                // Don't follow redirects unless we plan on validating content
-                followRedirect: false
-            };
+  return new Promise(async (resolve, reject) => {
+    const scope = 'https://purl.imsglobal.org/spec/lti-ap/scope/asset.readonly';
+    try {
+      const token = await getProcessorToken(aud, scope);
+      let options = {
+        method: 'GET',
+        uri: assetUrl,
+        headers: {
+          Authorization: 'Bearer ' + token
+        },
+        // Don't follow redirects unless we plan on validating content
+        followRedirect: false
+      };
 
-            request(options, function (err, response, body) {
-                if (response.statusCode === 200 || response.statusCode === 307 || response.statusCode === 302) {
-                    console.log("Successfully downloaded asset " + assetUrl);
-                    resolve();
-                } else {
-                    console.log("Unexpected download response: " + JSON.stringify(response));
-                    reject(err);
-                }
-            });
-        } catch (error) {
-            console.log(error);
-            reject(error);
+      request(options, function (err, response, body) {
+        if (response.statusCode === 200 || response.statusCode === 307 || response.statusCode === 302) {
+          console.log('Successfully downloaded asset ' + assetUrl);
+          resolve();
+        } else {
+          console.log('Unexpected download response: ' + JSON.stringify(response));
+          reject(err);
         }
-    });
-}
+      });
+    } catch (error) {
+      console.log(error);
+      reject(error);
+    }
+  });
+};
 
 const updateAssetStatus = (aud, statusUrl, resourceLinkId, assetId, assetStatus, score, maxScore) => {
-    return new Promise(async (resolve, reject) => {
-        const scope = "https://purl.imsglobal.org/spec/lti-ap/scope/report";
-        try {
-            const token = await getProcessorToken(aud, scope);
-            let payload = {
-                "processingProgress": assetStatus,
-                "assetId": assetId,
-                "resourceLinkId": resourceLinkId,
-                "type": "originality"
-            };
+  return new Promise(async (resolve, reject) => {
+    const scope = 'https://purl.imsglobal.org/spec/lti-ap/scope/report';
+    try {
+      const token = await getProcessorToken(aud, scope);
+      let payload = {
+        'processingProgress': assetStatus,
+        'assetId': assetId,
+        'resourceLinkId': resourceLinkId,
+        'type': 'originality'
+      };
 
-            if (assetStatus === "Processed" && score) {
-                payload["scoreGiven"] = score;
-                payload["scoreMaximum"] = maxScore;
-                if ( score > 80 ) {
-                    payload["indicationColor"] = "#FF0000";
-                    payload["indicationAlt"] = "Bad";
-                } else if ( score > 50 ) {
-                    payload["indicationColor"] = "#FFFF00";
-                    payload["indicationAlt"] = "Warning";
-                } else if ( score > 20 ) {
-                    payload["indicationColor"] = "#0000FF";
-                    payload["indicationAlt"] = "Probably OK";
-                } else {
-                    payload["indicationColor"] = "#3F704D";
-                    payload["indicationAlt"] = "Clear";
-                }
-            }
-
-            if (assetStatus === "Failed") {
-                payload["comment"] = "Fake Failure";
-            }
-
-            if (assetStatus === "NotProcessed") {
-                payload["comment"] = "File not supported";
-            }
-
-            let options = {
-                method: 'POST',
-                uri: statusUrl,
-                headers: {
-                    Authorization: 'Bearer ' + token,
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(payload)
-            };
-
-            request(options, function (err, response, body) {
-                if (response.statusCode < 300) {
-                    console.log("Set status to " + assetStatus + " for asset " + assetId);
-                    resolve();
-                } else {
-                    console.log("Unexpected asset set status response: " + JSON.stringify(response));
-                    reject(err);
-                }
-            });
-        } catch (error) {
-            console.log(error);
-            reject(error);
+      if (assetStatus === 'Processed' && score) {
+        payload['scoreGiven'] = score;
+        payload['scoreMaximum'] = maxScore;
+        if ( score > 80 ) {
+          payload['indicationColor'] = '#FF0000';
+          payload['indicationAlt'] = 'Bad';
+        } else if ( score > 50 ) {
+          payload['indicationColor'] = '#FFFF00';
+          payload['indicationAlt'] = 'Warning';
+        } else if ( score > 20 ) {
+          payload['indicationColor'] = '#0000FF';
+          payload['indicationAlt'] = 'Probably OK';
+        } else {
+          payload['indicationColor'] = '#3F704D';
+          payload['indicationAlt'] = 'Clear';
         }
-    });
-}
+      }
+
+      if (assetStatus === 'Failed') {
+        payload['comment'] = 'Fake Failure';
+      }
+
+      if (assetStatus === 'NotProcessed') {
+        payload['comment'] = 'File not supported';
+      }
+
+      let options = {
+        method: 'POST',
+        uri: statusUrl,
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      };
+
+      request(options, function (err, response, body) {
+        if (response.statusCode < 300) {
+          console.log('Set status to ' + assetStatus + ' for asset ' + assetId);
+          resolve();
+        } else {
+          console.log('Unexpected asset set status response: ' + JSON.stringify(response));
+          reject(err);
+        }
+      });
+    } catch (error) {
+      console.log(error);
+      reject(error);
+    }
+  });
+};

--- a/server/src/app/processor.js
+++ b/server/src/app/processor.js
@@ -4,6 +4,9 @@ import request from 'request';
 const SUBMISSION_TEXT_TITLE = 'Submission_Text.html';
 
 export const handleSubmissionNotice = async (req, res, jwtPayload) => {
+  const customClaims = jwtPayload.body['https://purl.imsglobal.org/spec/lti/claim/custom'];
+  console.log('Received custom claims:', JSON.stringify(customClaims));
+
   // We need to store the assets
   const assets = jwtPayload.body['https://purl.imsglobal.org/spec/lti-ap/claim/assetservice']['assets'];
   const statusUrl = jwtPayload.body['https://purl.imsglobal.org/spec/lti-ap/claim/assetreport']['report_url'];


### PR DESCRIPTION
This adds an example of requesting the `$ResourceLink.submission.endDateTime` substitution variable in the asset processor content item.