### PR TITLE
Substituting sub from payload

### DIFF
--- a/server/src/app/proctoring.js
+++ b/server/src/app/proctoring.js
@@ -10,7 +10,7 @@ export const buildProctoringStartReturnPayload = (req, res, proctoringPayload) =
     'https://purl.imsglobal.org/spec/lti/claim/version': '1.3.0',
     iss: proctoringPayload.body.iss,
     aud: proctoringPayload.body.iss,
-    sub: proctoringPayload.body.iss,
+    sub: proctoringPayload.body.sub,
     iat: now,
     exp: now + 5 * 60,
     'https://purl.imsglobal.org/spec/lti/claim/deployment_id': proctoringPayload.body['https://purl.imsglobal.org/spec/lti/claim/deployment_id'],


### PR DESCRIPTION
Ticket : https://dev.azure.com/AnthologyInc-01/Learn/_workitems/edit/2010904

RCA : To start a proctoring assessment they were getting userId from context which was causing issues for the preview user.

Fix : We are substituting the value of sub from the proctoring payload , so that we can use it in the learn side instead of getting from context.