### PR TITLE
fixed nrps that does not stop when there is no next link

### DIFF
--- a/server/src/app/names-roles.js
+++ b/server/src/app/names-roles.js
@@ -60,6 +60,8 @@ export const namesRoles = (req, res, nrPayload) => {
           nrPayload.next_url = '';
         } else {
           nrPayload.body = json;
+          nrPayload.difference_url = ''; //mbk - if we don't get a difference link, we should not display the button.
+          nrPayload.next_url = '';       //mbk - if we don't get a next link, we should not display the button.
           let links = response.headers.link.split(',');
           links.forEach(link => {
             if (link.includes('difference')) {

--- a/server/src/app/names-roles.js
+++ b/server/src/app/names-roles.js
@@ -60,8 +60,8 @@ export const namesRoles = (req, res, nrPayload) => {
           nrPayload.next_url = '';
         } else {
           nrPayload.body = json;
-          nrPayload.difference_url = ''; //mbk - if we don't get a difference link, we should not display the button.
-          nrPayload.next_url = '';       //mbk - if we don't get a next link, we should not display the button.
+          nrPayload.next_url = '';       //difference_url and next_url need to be set empty, otherwise they will retain the prior values.
+          nrPayload.difference_url = ''; 
           let links = response.headers.link.split(',');
           links.forEach(link => {
             if (link.includes('difference')) {


### PR DESCRIPTION
We want the NRPS code to stop displaying the next and differences buttons when these are not in the link data returned by Learn. It wasn't doing that because nrPayload.next_url and nrPayload.difference_url were staying set from the prior call to the service. We now clear them out before looking for them and setting them if they are in the response from Learn.