### PR TITLE
AB#2012594 Handling 204 response status from LTI AGS implementation

### DIFF
--- a/server/src/app/assign-grades.js
+++ b/server/src/app/assign-grades.js
@@ -258,7 +258,6 @@ export const scores = (req, res, agPayload, task) => {
       let columnId = agPayload.form.column;
       let gradingProgress = agPayload.form.gradingProgress;
       let activityProgress = agPayload.form.activityProgress;
-      let submittedAt = agPayload.form.submittedAt;
 
       let url = agPayload.form.url + '/scores';
 
@@ -281,11 +280,11 @@ export const scores = (req, res, agPayload, task) => {
           userId: userId,
           scoreGiven: newScore ? newScore : null,
           scoreMaximum: 100.0,
-          comment: 'This is exceptional work.',
+          comment: 'Modifed comment from tool for testing.',
           timestamp: '2017-04-16T18:54:36.736+00:00',
           activityProgress: activityProgress,
-          gradingProgress: gradingProgress,
-          submittedAt: submittedAt ? submittedAt : null
+          scoreMaximum: 100.0,
+          gradingProgress: gradingProgress
         };
         break;
       case 'submit':
@@ -312,10 +311,12 @@ export const scores = (req, res, agPayload, task) => {
       };
 
       request(options, function (err, response, body) {
-        let json = JSON.parse(body);
+        let json = body ? JSON.parse(body) : '';
 
         if (err) {
           //console.log('AGS Send Score Error - request failed: ' + err.message);
+        } else if (response.statusCode === 204) {
+          json = JSON.parse('{"status": "204", "message": "Score ignored as timestamp is earlier than the already graded date."}');
         } else if (response.statusCode !== 200) {
           /*console.log(
             'AGS Send Score Error - Service call failed: ' +
@@ -323,10 +324,8 @@ export const scores = (req, res, agPayload, task) => {
             '\n' +
             options.uri
           );*/
-          agPayload.body = json;
-        } else {
-          agPayload.body = json;
         }
+        agPayload.body = json;
         res.redirect('/assign_grades_view');
       });
     },

--- a/server/src/app/assign-grades.js
+++ b/server/src/app/assign-grades.js
@@ -258,6 +258,7 @@ export const scores = (req, res, agPayload, task) => {
       let columnId = agPayload.form.column;
       let gradingProgress = agPayload.form.gradingProgress;
       let activityProgress = agPayload.form.activityProgress;
+      let submittedAt = agPayload.form.submittedAt;
 
       let url = agPayload.form.url + '/scores';
 
@@ -283,7 +284,8 @@ export const scores = (req, res, agPayload, task) => {
           comment: 'This is exceptional work.',
           timestamp: '2017-04-16T18:54:36.736+00:00',
           activityProgress: activityProgress,
-                    gradingProgress: gradingProgress
+          gradingProgress: gradingProgress,
+          submittedAt: submittedAt ? submittedAt : null
         };
         break;
       case 'submit':

--- a/server/src/app/assign-grades.js
+++ b/server/src/app/assign-grades.js
@@ -317,7 +317,7 @@ export const scores = (req, res, agPayload, task) => {
         if (err) {
           //console.log('AGS Send Score Error - request failed: ' + err.message);
         } else if (response.statusCode === 204) {
-          json = JSON.parse('{"status": "204", "message": "Score ignored as timestamp is earlier than the already graded date."}');
+          json = {"status": 204, "message": "No content"};
         } else if (response.statusCode !== 200) {
           /*console.log(
             'AGS Send Score Error - Service call failed: ' +

--- a/server/src/app/assign-grades.js
+++ b/server/src/app/assign-grades.js
@@ -280,11 +280,10 @@ export const scores = (req, res, agPayload, task) => {
           userId: userId,
           scoreGiven: newScore ? newScore : null,
           scoreMaximum: 100.0,
-          comment: 'Modifed comment from tool for testing.',
+          comment: 'This is exceptional work.',
           timestamp: '2017-04-16T18:54:36.736+00:00',
           activityProgress: activityProgress,
-          scoreMaximum: 100.0,
-          gradingProgress: gradingProgress
+                    gradingProgress: gradingProgress
         };
         break;
       case 'submit':


### PR DESCRIPTION
Learn PR: [AB#2012594](https://github.com/blackboard-learn/learn/pull/2464)

**Issue:**
LTI AGS implementation in learn was changed to send response status 204, which represents NO CONTENT, when the timestamp sent as part of input JSON is older than the already graded date. But the LTI testing tool does handle this new status code.

**RCA:**
On analysis found that the new status code change needs to be done in assign-grades.js

**Fix:**
Made changes to handle status code 204.