### PR TITLE
Add a Resize Frame button to test lti.frameResize events

### DIFF
--- a/public/src/components/pages/ltiAdvView.js
+++ b/public/src/components/pages/ltiAdvView.js
@@ -111,6 +111,10 @@ export default class LtiAdvView extends React.Component {
         })
         .catch(error => alert('Display capture access denied!', error));
     };
+    const resizeFrame = () => {
+      const height = window.innerHeight > 500 ? 500 : 600;
+      window.parent.postMessage({ subject: 'lti.frameResize', height }, '*');
+    };
     const closeTracks = (stream) => {
       stream.getTracks().forEach(track => {
         if (track.readyState == 'live') {
@@ -141,6 +145,9 @@ export default class LtiAdvView extends React.Component {
             </Grid>
             <Grid item xs>
               <Button variant='contained' color='secondary' onClick={() => checkDisplayCap()}>Test Display Capture</Button>
+            </Grid>
+            <Grid item xs>
+              <Button variant='contained' color='secondary' onClick={() => resizeFrame()}>Resize Frame</Button>
             </Grid>
             <Grid item xs>
               <form action={this.state.returnUrl} method='post'>


### PR DESCRIPTION
Adds a button that fires an `lti.frameResize` event to the parent window. The change itself isn't particularly inspired, but it allows testing the event.

[Ultra PR](https://github.com/blackboard-learn/ultra/pull/7770) that adds support for this event in documents.

<details>
  <summary>Screenshot of the new button embedded in an Ultra document</summary>
 
![image](https://github.com/user-attachments/assets/17286f7b-d1c4-4306-871a-0c678735256b)
</details>